### PR TITLE
Implemented friendly fire option

### DIFF
--- a/Armament/Assets/MyScripts/Game/GameManager.cs
+++ b/Armament/Assets/MyScripts/Game/GameManager.cs
@@ -68,6 +68,8 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         [SerializeField] private Transform[] teamBPlayerSpawnPoints;
         [Tooltip("List of locations where a weapon can be spawned")]
         [SerializeField] private Transform[] weaponSpawnPoints;
+        [Tooltip("Whether players can damage players on same team")]
+        [SerializeField] private bool friendlyFire;
 
         [Tooltip("")]
         [SerializeField] private GameObject playerData;
@@ -116,6 +118,8 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         #endregion Private Fields
 
         #region Properties
+
+        public bool FriendlyFire { get; private set; }
 
         // USE WITH CARE! 
         // It can start with any positive value.
@@ -719,6 +723,9 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             Debug.Log("Awake():");
             // Singleton!
             Instance = this;
+
+            // Set public property to the value set in inspector
+            FriendlyFire = friendlyFire;
         }
 
         void Update()

--- a/Armament/Assets/MyScripts/Game/PlayerManager.cs
+++ b/Armament/Assets/MyScripts/Game/PlayerManager.cs
@@ -85,7 +85,8 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         private const bool DEBUG_OnPhotonInstantiate = true;
         private const bool DEBUG_ProcessInputs = true;
         private const bool DEBUG_SetAvatar = true;
-        
+        private const bool DEBUG_TakeDamage = true; 
+
         private AudioSource audioSource;
 
         private ArrayList playerWeapons;
@@ -562,6 +563,12 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             // If the player being damaged is the one this client owns...
             if (photonView.IsMine)
             {
+                if (GameManager.Instance.FriendlyFire == false && playerWhoCausedDamage.GetTeam().Equals(GetTeam()))
+                {
+                    if (DEBUG && DEBUG_TakeDamage) Debug.Log("PlayerManager: TakeDamage() Players are on same team. Not logging damage.");
+                    return;
+                }
+
                 if (Shield > 0)
                 {
                     // Player's Shield takes damage equal to amount of damage inflicted


### PR DESCRIPTION
Default = no friendly fire. Set in Game Manager in inspector.
PlayerManager.TakeDamage(int,PlayerManager) checks if GameManager.FriendlyFire and if player taking damage is on the same team as player giving damage.