### PR TITLE
Remedial Stats

### DIFF
--- a/Armament/Assets/MyScenes/Simple Room 2.unity
+++ b/Armament/Assets/MyScenes/Simple Room 2.unity
@@ -808,6 +808,18 @@ MonoBehaviour:
   viewIdField: 2
   InstantiationId: 2
   isRuntimeInstantiated: 0
+--- !u!114 &2033645112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033645110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec5a72124feb448dab1fa025609e7510, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &6519157859644779366
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Armament/Assets/MyScenes/Simple Room.unity
+++ b/Armament/Assets/MyScenes/Simple Room.unity
@@ -680,49 +680,6 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!1 &1358594361
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1358594363}
-  - component: {fileID: 1358594362}
-  m_Layer: 0
-  m_Name: GamePlayFabController
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1358594362
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1358594361}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ec5a72124feb448dab1fa025609e7510, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &1358594363
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1358594361}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 447, y: 267, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1359000010 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6519157861003696812, guid: 4c23e69ee0b960e48a820ef33bb98be0,
@@ -1220,6 +1177,18 @@ MonoBehaviour:
   viewIdField: 2
   InstantiationId: 2
   isRuntimeInstantiated: 0
+--- !u!114 &2033645112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2033645110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec5a72124feb448dab1fa025609e7510, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2066903988
 GameObject:
   m_ObjectHideFlags: 0

--- a/Armament/Assets/MyScenes/Space_Arena.unity
+++ b/Armament/Assets/MyScenes/Space_Arena.unity
@@ -124,49 +124,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8618787994525641690}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &591693766
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 591693768}
-  - component: {fileID: 591693767}
-  m_Layer: 0
-  m_Name: GamePlayFabController
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &591693767
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 591693766}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ec5a72124feb448dab1fa025609e7510, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &591693768
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 591693766}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 447, y: 267, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &877612531
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -446,6 +403,18 @@ MonoBehaviour:
   viewIdField: 2
   InstantiationId: 2
   isRuntimeInstantiated: 0
+--- !u!114 &877612535
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 877612532}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec5a72124feb448dab1fa025609e7510, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &1012032549 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1012032549, guid: 6ea03386c3065c04a9a5b717520118ec,

--- a/Armament/Assets/MyScripts/Game/GameManager.cs
+++ b/Armament/Assets/MyScripts/Game/GameManager.cs
@@ -268,6 +268,12 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                 Transform playerInfoPanel = canvas.transform.Find("Player Info Panel");
                 playerInfoPanel.gameObject.SetActive(false);
             }
+
+            //TODO: Method to show functionality of stats  until AddKill() is called  successfully
+            if (Input.GetKeyUp(KeyCode.K))
+            {
+                GetComponent<GamePlayFabController>().IncrementKillCount();
+            }
 #endif
         }
 
@@ -571,13 +577,13 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         [PunRPC]
         void PlayNewRoundSound()
         {
-           /* GameObject announcer = new GameObject("Announcer");
-            AudioSource audioSource = announcer.AddComponent<AudioSource>();
-            Debug.LogFormat("PlayerManager: Die() audioSource = {0}, newRoundSound = {1}", audioSource, newRoundSound);
+            /* GameObject announcer = new GameObject("Announcer");
+             AudioSource audioSource = announcer.AddComponent<AudioSource>();
+             Debug.LogFormat("PlayerManager: Die() audioSource = {0}, newRoundSound = {1}", audioSource, newRoundSound);
 
-            // Play death sound
-            audioSource.PlayOneShot(newRoundSound); // I read somewhere online that this allows the sounds to overlap
-            Destroy(announcer, 5f);*/
+             // Play death sound
+             audioSource.PlayOneShot(newRoundSound); // I read somewhere online that this allows the sounds to overlap
+             Destroy(announcer, 5f);*/
         }
 
         /// <summary>
@@ -824,7 +830,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                 if (DEBUG && DEBUG_OnPlayerDeath) Debug.Log("GameManager: OnPlayerDeath() NOT MASTER CLIENT: Doing nothing...");
                 return;
             }
-            
+
             if (!roundEndsWhenLastOpponentDies)
             {
                 if (DEBUG && DEBUG_OnPlayerDeath) Debug.Log("GameManager: OnPlayerDeath() CLIENT IS MasterClient: " +
@@ -862,7 +868,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             {
                 if (DEBUG && DEBUG_OnPlayerDeath) Debug.Log("GameManager: OnPlayerDeath() CLIENT IS MasterClient: " +
                     "morePlayersOnTeamStillAlive = false, so Ending this round...");
-                
+
                 // End this round (which will start a new round)
                 EndRound();
             }

--- a/Armament/Assets/MyScripts/Game/PlayerManager.cs
+++ b/Armament/Assets/MyScripts/Game/PlayerManager.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using Photon.Pun;
 using System;
 using Photon.Realtime;
+using PlayFab;
 using System.Collections.Generic;
 
 namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
@@ -21,7 +22,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         // Key references for the Player CustomProperties hash table (so we don't use messy string literals)
         public const string KEY_KILLS = "Kills";
         public const string KEY_DEATHS = "Deaths";
-        public const string KEY_MODE = "Mode"; 
+        public const string KEY_MODE = "Mode";
         public const string KEY_TEAM = "Team";
         public const string KEY_ACTIVE_GUN = "Active Gun";
 
@@ -88,22 +89,22 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         private const bool DEBUG_ProcessInputs = false;
         private const bool DEBUG_SetAvatar = false;
         private const bool DEBUG_TakeDamage = false;
-        private const bool DEBUG_SetMode = true; 
+        private const bool DEBUG_SetMode = true;
 
         private AudioSource audioSource;
 
         private ArrayList playerWeapons;
         private GameObject gunToBePickedUpGO; // stores a reference to the a gun we want to pick up
         private Vector3 activeGunPosition;
-        
+
         private int activeGunType; // keeps track of currently active gun's type 
         private int previousActiveGunType; // keeps track of previously active gun's type
         private Gun activeGun; // keeps track of active gun the active gun: a gun that is synced on network
         private Gun activeShowGun; // keeps track of the active "show" gun: a gun that is not synced on network (instantiated locally) and used to visually and functionally represent activeGun
         private object[] instantiationData; // information that was linked with this Gun's GO when it was instantiated by the master client
         private bool selectingWeapon; // flag to keep track of whether user is trying to select a weapon
-        private int weaponSelectionIndex; 
-        
+        private int weaponSelectionIndex;
+
         private GameObject playerGO;
         private GameObject unityChanPrefab;
         private GameObject kyleRobotPrefab;
@@ -128,13 +129,14 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
 
             if (DEBUG && DEBUG_Awake) Debug.LogFormat("PlayerManager: Awake() actorNumber = {0}, PhotonNetwork.LocalPlayer.ActorNumber = {1}", actorNumber, PhotonNetwork.LocalPlayer.ActorNumber);
 
-            if (PhotonNetwork.LocalPlayer.ActorNumber == actorNumber) {
+            if (PhotonNetwork.LocalPlayer.ActorNumber == actorNumber)
+            {
                 //if (!photonView.IsMine)
                 //{
-                    if (DEBUG && DEBUG_Awake) Debug.LogFormat("PlayerManager: Awake() Transferring ownership to PhotonNetwork.LocalPlayer = {0}", PhotonNetwork.LocalPlayer);
-                    GetComponent<PhotonView>().TransferOwnership(PhotonNetwork.LocalPlayer);
+                if (DEBUG && DEBUG_Awake) Debug.LogFormat("PlayerManager: Awake() Transferring ownership to PhotonNetwork.LocalPlayer = {0}", PhotonNetwork.LocalPlayer);
+                GetComponent<PhotonView>().TransferOwnership(PhotonNetwork.LocalPlayer);
                 //}
-                
+
                 // #Important
                 // used in GameManager.cs: we keep track of the localPlayer instance to prevent instantiation when levels are synchronized
                 if (DEBUG && DEBUG_Awake) Debug.LogFormat("PlayerManager: Awake() Setting PlayerManager.LocalPlayerInstance = {0}", gameObject);
@@ -168,7 +170,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                 // Call SetTarget() on PlayerInfoUI component so the PlayerInfoUI will follow be linked to this player 
                 playerInfoUIGO.SendMessage("SetTarget", this, SendMessageOptions.RequireReceiver);
             }
-            
+
             // #Critical
             // we flag as don't destroy on load so that instance survives level synchronization, thus giving a seamless experience when levels load.
             DontDestroyOnLoad(this.gameObject);
@@ -182,7 +184,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         [PunRPC]
         public void SetAvatar(string avatarChoice)
         {
-            
+
             /*Debug.LogFormat("PlayerManager: SetAvatar() avatarChoice = {0}, avatarChoice.Equals(\"KyleRobot\") = {1}", avatarChoice, avatarChoice.Equals("KyleRobot "));
             // If user chooses kyle...
             //if (playerData.GetComponent<PlayerData>().GetAvatarChoice().Equals("KyleRobot"))
@@ -225,7 +227,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         {
             if (DEBUG && DEBUG_Start) Debug.LogFormat("PlayerManager: Start() ");
             //Debug.Log("Start(): Avatar choice coming from Launcher scene into PlayerData: " + PlayerData.GetComponent<PlayerData>().GetAvatarChoice());
- 
+
             audioSource = GetComponent<AudioSource>();
             if (!audioSource)
             {
@@ -283,7 +285,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             {
                 ProcessInputs();
             }
-            
+
             // Regenerate Shield
             if (Shield < MAX_SHIELD)
             {
@@ -377,7 +379,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             {
                 transform.position = new Vector3(0f, 5f, 0f);
             }
-            
+
             /** Note from tutorial:
              *   when a new level is loaded, the UI is being 
              *   destroyed yet our player remains... so we need to instantiate it as well when we know a level was loaded
@@ -427,7 +429,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                 if (currentOwner.Equals(photonView.Owner.NickName))
                 {
                     if (DEBUG && DEBUG_OnRoomPropertiesUpdate) Debug.LogFormat("PlayerManager: OnRoomPropertiesUpdate() About to pick up gun: gunViewID = {0}", gunViewID);
-                    
+
                     // If we go to this point, we have collided with an unclaimed gun and we have successfully claimed ownership of the gun
                     // in CurrentRoom.CustomProperties. We now want the player (on all clients) to pick up the gun and make it the active gun.
                     // 
@@ -476,10 +478,10 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             {
                 // Get the value for the key
                 changedProps.TryGetValue(key, out object value);
-                
+
                 // If the player property that changed was KEY_ACTIVE_GUN...
                 if (KEY_ACTIVE_GUN.Equals((string)key))
-                {   
+                {
                     // If the KEY_ACTIVE_GUN value was just removed... 
                     if (value == null)
                     {
@@ -526,7 +528,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         /// <param name="team"></param>
         public void SetTeam(string team)
         {
-            photonView.Owner.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { {KEY_TEAM, team} });
+            photonView.Owner.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { { KEY_TEAM, team } });
         }
 
         public string GetTeam()
@@ -589,7 +591,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                     // Player's Shield takes damage equal to amount of damage inflicted
                     Shield -= amount;
                     // Player's health takes damage proportional to the amount of shield they have left
-                    Health -= (1 - Shield/MAX_SHIELD) * amount;
+                    Health -= (1 - Shield / MAX_SHIELD) * amount;
                 }
                 else
                 {
@@ -680,12 +682,12 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                 transform.position = transform.position + new Vector3(0f, 20f, 0f);
                 Update();
                 transform.GetComponent<FirstPersonController>().enabled = true;*/
-                
+
                 // Move player to spawn point
                 MovePlayer(playerSpawnPoint);
             }
         }
-        
+
         public void StartDeadSpectatorMode()
         {
             // Sync player's mode (whether they are alive or dead and spectating)
@@ -819,7 +821,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
 
             // Protect against double collisions (trying to pick up the same gun twice)
             // *** This check might not be necessary after recent code changes... TODO: look into it
-            
+
             if (pickedUpGun.Equals(activeGun))//sometimes this is null for some reason.
             {
                 return;
@@ -908,7 +910,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
 
             // If this client owns the player dropping the gun...
             if (photonView.IsMine)
-            {                
+            {
                 // Transfer Gun's PhotonView ownership to the "Scene"
                 gun.GetComponent<PhotonView>().TransferOwnership(0);
             }
@@ -974,7 +976,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             int deaths = (value == null) ? 0 : Convert.ToInt32(value);
 
             // Add a death for this player
-            photonView.Owner.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { {KEY_DEATHS, ++deaths} });
+            photonView.Owner.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { { KEY_DEATHS, ++deaths } });
 
             if (DEBUG) Debug.LogFormat("PlayerManager: AddDeath() deaths = {0}, photonView.Owner.NickName = {1}", deaths, photonView.Owner.NickName);
         }
@@ -985,17 +987,18 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         /// </summary>
         void AddKill()
         {
-            //Add Kill to player's db stats
-            //var addKillScript = GameObject.Find("GamePlayFabController").GetComponent<GamePlayFabController>();
-            //addKillScript.IncrementKillCount();
-
             // Get current deaths for this player
             photonView.Owner.CustomProperties.TryGetValue(KEY_KILLS, out object value);
             int kills = (value == null) ? 0 : Convert.ToInt32(value);
 
+
+            //TODO: This is the test method for Stat sync. It turns out that this AddKill() method never actually gets called. If the method
+            //is called this line below will increment the player's kill count stat.
+            GameManager.Instance.GetComponent<GamePlayFabController>().IncrementKillCount();
+
             // Add a kill for this player
             photonView.Owner.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { { KEY_KILLS, ++kills } });
-            
+
             if (DEBUG) Debug.LogFormat("PlayerManager: AddKill() kills = {0}, photonView.Owner.NickName = {1}", kills, photonView.Owner.NickName);
         }
 
@@ -1024,7 +1027,8 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             }
 
             // If user is not currently selecting a weapon
-            if (!selectingWeapon) { 
+            if (!selectingWeapon)
+            {
                 if (Input.GetButtonDown("Fire1"))
                 {
                     // we don't want to fire when we interact with UI buttons for example. IsPointerOverGameObject really means IsPointerOver*UI*GameObject
@@ -1061,7 +1065,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             else
             {
                 GameObject weaponInventoryMenuGO = GameManager.Instance.canvas.transform.Find("Weapon Inventory Menu").gameObject;
-                
+
                 // If user wants to highlight previous weapon
                 if (Input.mouseScrollDelta.y > 0)
                 {
@@ -1097,7 +1101,8 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             // If has pressed and released the G key...
             if (Input.GetKeyUp(KeyCode.G))
             {
-                if (activeGun == null) {
+                if (activeGun == null)
+                {
                     if (DEBUG && DEBUG_ProcessInputs) Debug.Log("PlayerManager: ProcessInputs() Trying to drop active gun but this.activeGun == null");
                     return;
                 }
@@ -1119,24 +1124,14 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                 {
                     GameObject fragGrenade = PhotonNetwork.Instantiate("FragGrenade", gameObject.transform.position, gameObject.transform.rotation);
                     fragGrenade.GetComponent<FragGrenade>().playerWhoOwnsThisGrenade = this;//setting this for TakeDamage(int/float,playerwhoowns...)
-                                     
+
                     //yield return new WaitForSeconds(2.0f);
                     //PhotonNetwork.Destroy(skycar);
                     //StartCoroutine("DestroyCar", skyCar);
                 }
-                
-            }
-
-            if (Input.GetKeyUp(KeyCode.K))
-            {
-                if (photonView.IsMine)//network ismasterclient
-                {
-                    //Add Kill to player's db stats
-                    var addKillScript = GameObject.Find("GamePlayFabController").GetComponent<GamePlayFabController>();
-                    addKillScript.IncrementKillCount();
-                }
 
             }
+
 
             if (Input.GetKeyUp(KeyCode.Alpha1))
             {
@@ -1182,7 +1177,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         void SwapActiveGun(int gunType)
         {
             if (DEBUG && DEBUG_SwapGun) Debug.LogFormat("PlayerManager: SwapGun gunType = {0}", gunType);
-            
+
             // Find a gun in player inventory matching the gun type and set it as our active gun
             Transform inactiveWeapons = transform.Find("FirstPersonCharacter/Inactive Weapons");
             for (int i = 0; i < inactiveWeapons.childCount; i++)
@@ -1212,7 +1207,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             // Make player on this client drop the gun
             DropGun(activeGun);
         }
-        
+
         /// <summary>
         /// Shoot was invoked over photon network via RPC
         /// </summary>
@@ -1224,14 +1219,14 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             if (activeGun == null)
             {
                 if (DEBUG) Debug.LogFormat("PlayerManager: [PunRPC] Shoot() Trying to shoot gun but activeGun = null");
-                return; 
+                return;
             }
 
             /*
             // Tell the gun to shoot
             activeGun.Shoot();
             */
-            
+
             // Tell the "show" gun to shoot
             activeShowGun.Shoot();
         }
@@ -1356,12 +1351,12 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         public void OnPhotonInstantiate(PhotonMessageInfo info)
         {
             if (DEBUG && DEBUG_OnPhotonInstantiate) Debug.LogFormat("PlayerManager: OnPhotonInstantiate() info.Sender = {0}, gameObject = {1}", info.Sender, gameObject);
-            
+
             instantiationData = GetComponent<PhotonView>().InstantiationData;
             int actorNumber = (int)instantiationData[0];
             Player thisPlayer = PhotonNetwork.CurrentRoom.GetPlayer(actorNumber);
 
-            if (DEBUG && DEBUG_OnPhotonInstantiate)  Debug.LogFormat("PlayerManager: OnPhotonInstantiate() actorNumber = {0}, thisPlayer = {1}", actorNumber, thisPlayer);
+            if (DEBUG && DEBUG_OnPhotonInstantiate) Debug.LogFormat("PlayerManager: OnPhotonInstantiate() actorNumber = {0}, thisPlayer = {1}", actorNumber, thisPlayer);
 
             if (thisPlayer != null)
             {
@@ -1381,9 +1376,9 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                     catch (Exception) { continue; }
 
                     if (DEBUG && DEBUG_OnPhotonInstantiate) Debug.LogFormat("PlayerManager: OnPhotonInstantiate() gunViewID = {0} ", gunViewID);
-                                        
+
                     Gun gun = PhotonView.Find(gunViewID).GetComponent<Gun>();
-                    
+
                     // If this gun has a registered owner (player) in the room's CustomProperties...
                     if (PhotonNetwork.CurrentRoom.CustomProperties.TryGetValue(gunViewID.ToString(), out object gunOwnerNickName))
                     {

--- a/Armament/Assets/MyScripts/PlayFab/GamePlayFabController.cs
+++ b/Armament/Assets/MyScripts/PlayFab/GamePlayFabController.cs
@@ -10,6 +10,9 @@ public class GamePlayFabController : MonoBehaviour
     public static GamePlayFabController GPFC;
     public SceneManager SM;
 
+    private int playerKillCountThisGame;
+    private int playerTotalKills;
+
     private void OnEnable()
     {
         if (GamePlayFabController.GPFC == null)
@@ -35,29 +38,13 @@ public class GamePlayFabController : MonoBehaviour
         }
 
         playerKillCountThisGame = 0;
-        //setStats();
-        //getStats();
+        GetStats();
     }
 
     #region PlayerStats
 
-    private int playerKillCountThisGame;
-    private int playerTotalKills;
-
-    public void setStats()
-   {
-        PlayFabClientAPI.UpdatePlayerStatistics(new UpdatePlayerStatisticsRequest
-        {
-            // request.Statistics is a list, so multiple StatisticUpdate objects can be defined if required.
-            Statistics = new List<StatisticUpdate> {
-            new StatisticUpdate { StatisticName = "PlayerKillCount", Value = playerTotalKills + playerKillCountThisGame }
-            }
-        },
-        result => { Debug.Log("User statistics updated"); },
-        error => { Debug.LogError(error.GenerateErrorReport()); });
-    }
-
-    void getStats()
+    //Receive stats from database
+    void GetStats()
     {
         PlayFabClientAPI.GetPlayerStatistics(
             new GetPlayerStatisticsRequest(),
@@ -66,6 +53,7 @@ public class GamePlayFabController : MonoBehaviour
         );
     }
 
+    //Log each stat to the user
     void OnGetStatistics(GetPlayerStatisticsResult result)
     {
         Debug.Log("Received the following Statistics:");
@@ -97,10 +85,10 @@ public class GamePlayFabController : MonoBehaviour
     {
         // Cloud Script returns arbitrary results, so you have to evaluate them one step and one parameter at a time
         Debug.Log(JsonWrapper.SerializeObject(result.FunctionResult));
-        JsonObject jsonResult = (JsonObject)result.FunctionResult;
-        object messageValue;
-        jsonResult.TryGetValue("messageValue", out messageValue); // note how "messageValue" directly corresponds to the JSON values set in Cloud Script
-        Debug.Log((string)messageValue);
+        //JsonObject jsonResult = (JsonObject)result.FunctionResult;
+        //object messageValue;
+        //jsonResult.TryGetValue("messageValue", out messageValue); // note how "messageValue" directly corresponds to the JSON values set in Cloud Script
+        //Debug.Log((string)messageValue);
     }
 
     private static void OnErrorShared(PlayFabError error)
@@ -112,7 +100,9 @@ public class GamePlayFabController : MonoBehaviour
     {
         Debug.Log("Incrementing Kill Count...");
         playerKillCountThisGame++;
+        GetStats();
         StartCloudUpdatePlayerStats();
+
     }
 
     #endregion PlayerStats


### PR DESCRIPTION
Just the functionality to press K to increment your kill count while in game.

I put TODO's in the PlayerManager script around where the function should be called. I placed it in AddKill() but AddKill() was never called for me. I believe it may be due to the fact that I was only able to test with two players, so any kill would immediately restart the match, though I don't know. 

There's also a slight glitch that wasn't present before in that the stat goes up by one for three iterations, then starts going up by more...I'm not sure what's causing it but there's more pressing matters at the moment so I'll revisit shortly