### PR TITLE
2 Bug fixes in 1 line of code

### DIFF
--- a/Armament/Assets/MyScripts/Game/PlayerManager.cs
+++ b/Armament/Assets/MyScripts/Game/PlayerManager.cs
@@ -657,7 +657,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             */
 
             // Move the player to the target position
-            this.transform.parent.GetComponent<CharacterController>().Move(t.position - transform.position);
+            GetComponent<CharacterController>().Move(t.position - transform.position);
 
             if (DEBUG && DEBUG_MovePlayer) Debug.LogFormat("PlayerManager: MovePlayer() transform.position = {0}", transform.position);
         }


### PR DESCRIPTION
A beautiful thing. One line of code in PlayerManager.MovePlayer() throwing a null reference exception was causing two bugs:
1) Player failing to move back to spawn point at beginning of new round
2) Weapons failing to return to their spawn points at the beginning of new round