### PR TITLE
Two bug fixes for Leave Room button click action

### DIFF
--- a/Armament/Assets/MyScripts/Game/GameManager.cs
+++ b/Armament/Assets/MyScripts/Game/GameManager.cs
@@ -288,6 +288,10 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         /// </summary>
         void UpdatePlayerPropertiesDisplay()
         {
+            // Don't try to update the display if we're not in a room
+            if (!PhotonNetwork.InRoom)
+                return;
+
             // Get the text component where we want to display all players' properties
             Transform playerInfoText = canvas.transform.Find("Player Info Panel/Player Info List Scroll View/Viewport/Content/Player Info Text");
             Text playerInfoTextComponent = playerInfoText.GetComponent<Text>();

--- a/Armament/Assets/MyScripts/Game/GameManager.cs
+++ b/Armament/Assets/MyScripts/Game/GameManager.cs
@@ -195,6 +195,12 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         {
             if (DEBUG && DEBUG_LeaveRoom) Debug.Log("GameManger: LeaveRoom() called.");
 
+            // Turn on scene cameras
+            // Make sure they're on for the brief moment between destruction of their player's camera
+            // and the new scene being loaded
+            sceneCameras[0].enabled = true;
+            sceneCameras[1].enabled = true;
+
             // Leave the photon game room
             PhotonNetwork.LeaveRoom();
 


### PR DESCRIPTION
Fix 1: Null reference exception in GameManager.UpdatePropertiesMenu()
Fix 2: No camera active after player is destroyed but before launcher scene is loaded. 
See individual commits for more info.
Easy test: Join a room, leave the room. Everything look honky dory?