### PR TITLE
Extend Wall Timer when Gun is picked up

### DIFF
--- a/Armament/Assets/MyScripts/Game/GameManager.cs
+++ b/Armament/Assets/MyScripts/Game/GameManager.cs
@@ -100,7 +100,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         private const bool DEBUG_OnStage1TimerIsExpired = true;
         private const bool DEBUG_OnStage2TimerIsExpired = true;
         private const bool DEBUG_BalanceTeams = false;
-        private const bool DEBUG_StartRound = true;
+        private const bool DEBUG_StartRound = false;
         private const bool DEBUG_EndRound = false;
         private const bool DEBUG_LeaveRoom = false;
         private const bool DEBUG_LoadArena = false;
@@ -110,7 +110,8 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         private const bool DEBUG_ResetPlayerPosition = false;
         private const bool DEBUG_SpawnWall = false;
         private const bool DEBUG_OnPlayerDeath = false;
-        private const bool DEBUG_OnWallReachedDropPosition = true;
+        private const bool DEBUG_OnWallReachedDropPosition = false;
+        private const bool DEBUG_OnPlayerPickedUpGun = true; 
 
         // Event codes
         private readonly byte InstantiatePlayer = 0;
@@ -162,9 +163,40 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             private set { dividingWallGO = value; }
         }
 
+        public Transform[] WeaponSpawnPoints
+        {
+            get { return weaponSpawnPoints; }
+            private set { weaponSpawnPoints = value; }
+        }
+
         #endregion
 
         #region Public Methods
+
+
+        public void ExtendStage1Time()
+        {
+            if (!PhotonNetwork.IsMasterClient)
+            {
+                if (DEBUG && DEBUG_OnPlayerPickedUpGun) Debug.Log("GameManager: OnPlayerPickedUpGun() NOT MasterClient: not responsible for extending stage 1 time");
+                return;
+            }
+
+            // If in stage 1
+            if (!PhotonNetwork.CurrentRoom.CustomProperties.ContainsKey(KEY_STAGE_2_COUNTDOWN_START_TIME) &&
+                PhotonNetwork.CurrentRoom.CustomProperties.TryGetValue(KEY_STAGE_1_COUNTDOWN_START_TIME, out object stage1Time))
+            {
+                float timeExtension = 5f; // Alex: I hard-coded 5 seconds until we figure out a more reasonable calculation for time extension
+
+                // Extend the stage 1 timer on the network
+                // *** This is actually kind of a hacky way to accomplish a stage time extension.
+                // *** Instead of extending the Stage 1 end time we're pretending the stage 1 start time was started timeExtension seconds after it actually did
+                // *** because we currently don't have an explicit reference to the stage 1 end time. 
+                // *** This was just a faster implementation than restructuring code in CountdownTimer script
+                PhotonNetwork.CurrentRoom.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { { KEY_STAGE_1_COUNTDOWN_START_TIME, (float)stage1Time + timeExtension } });
+            }
+
+        }
 
         /// <summary>
         /// Event Handler. Called in the event that the game's stage 1 timer is expired

--- a/Armament/Assets/MyScripts/Game/PlayerManager.cs
+++ b/Armament/Assets/MyScripts/Game/PlayerManager.cs
@@ -463,6 +463,19 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                     // If this client owns this player...
                     if (photonView.IsMine)
                     {
+                        // For each weapon spawn point
+                        foreach (Transform spawnPointTransform in GameManager.Instance.WeaponSpawnPoints)
+                        {
+                            // If the gun is at a spawn point...
+                            if (spawnPointTransform.position.Equals(PhotonView.Find(Convert.ToInt32(gunViewID)).gameObject.transform.position))
+                            {
+                                // Notify GameManager that the Stage 1 timer should be extended
+                                // because we picked up a gun
+                                GameManager.Instance.ExtendStage1Time();
+                                break;
+                            }
+                        }
+
                         // Set local player's active gun property (synced on the network)
                         PhotonNetwork.LocalPlayer.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { { KEY_ACTIVE_GUN, gunViewID } });
                     }


### PR DESCRIPTION
Now the wall timer will be extended if a gun is picked up during stage 1 at a weapon spawn point. It was important to make sure the gun was at a spawn point to prevent players dropping the gun and picking it back up repeatedly to extend the timer forever
I hard-coded a 5 second extension but this can be easily changed in the future if we want. We might want to take into account how many players are playing and/or how many guns are available to be picked up.