### PR TITLE
Wall health regen

### DIFF
--- a/Armament/Assets/MyScripts/Game/WallTarget.cs
+++ b/Armament/Assets/MyScripts/Game/WallTarget.cs
@@ -11,7 +11,11 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         // Key references for the Room CustomProperties hash table (so we don't use messy string literals)
         public const string KEY_WALL_HEALTH = "Wall Health";
 
+        [Tooltip("How many shield points to regenerate per second")]
+        public float HealthRegenerationRate = 10f;
+
         [SerializeField] private float health = 100f;
+
         MeshRenderer meshRenderer;
         private float originalHealth; // keeps track of original health value
 
@@ -23,6 +27,20 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             originalHealth = health;
             meshRenderer = GetComponent<MeshRenderer>();
             SyncWallHealth();
+        }
+
+        void Update()
+        {
+            // If health can be regenerated...
+            if (health < originalHealth && health > 0)
+            {
+                // Regenerate Health
+                // *** Important note: We won't explicitly sync health every time it is regenerated because that
+                // *** would overload the network. We'll rely on each client to be able to regenerate the health
+                // *** of the wall for themselves. Me thinks this will work just fine!
+                health += Math.Min(HealthRegenerationRate * originalHealth/100 * Time.deltaTime, originalHealth);
+                UpdateWallColor();
+            }
         }
 
         #endregion MonoBehaviour CallBacks


### PR DESCRIPTION
I made the regen rate independent of the wall's max/original health. In other words, if regen rate is 5 that's like saying the wall will regain 5% of its original health every second. This way, when we want to figure out how strong we want the wall to be, we don't have to readjust the the regen rate to compensate for a stronger/weaker wall.