### PR TITLE
Bugfixes: cleaned up dontdestroyonload garbage, added Enter to log in feature, and deleted random room status text, 

### DIFF
--- a/Armament/Assets/MyScripts/Game/GameManager.cs
+++ b/Armament/Assets/MyScripts/Game/GameManager.cs
@@ -936,7 +936,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
 
         void Start()
         {
-            DontDestroyOnLoad(this.gameObject);//tentative fix for null gameobject, but it happened after i left the room when i put this line in. gotta look into this
+            //DontDestroyOnLoad(this.gameObject);//tentative fix for null gameobject, but it happened after i left the room when i put this line in. gotta look into this
             if (PlayerPrefab1 == null)
             {
                 Debug.LogError("<Color=Red><a>Missing</a></Color> PlayerPrefab1 Reference. Please set it up in GameObject 'Game Manager'", this);

--- a/Armament/Assets/MyScripts/Launcher/Launcher.cs
+++ b/Armament/Assets/MyScripts/Launcher/Launcher.cs
@@ -378,9 +378,6 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             // #Critical: We only load if we are the first player, else we rely on 'PhotonNetwork.AutomaticallySyncScene' to sync our instance scene.
             if (PhotonNetwork.CurrentRoom.PlayerCount == 1)
             {
-                Debug.Log("We load the '"+ developmentOnly_levelToLoad + "'");
-
-
                 // Get the arena filter information
                 int arenaFilterIndex = arenaFilterDropdown.value;
                 string selectedArenaFilter = arenaFilterDropdown.options[arenaFilterIndex].text;

--- a/Armament/Assets/MyScripts/PlayFab/PlayFabController.cs
+++ b/Armament/Assets/MyScripts/PlayFab/PlayFabController.cs
@@ -139,6 +139,10 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                 }
                 else Debug.Log("next nagivation element not found");
             }
+            else if (Input.GetKeyDown(KeyCode.Return))
+            {
+                OnClickLogin();
+            }
         }
 
         #region Login

--- a/Armament/Assets/MyScripts/PlayFab/PlayFabController.cs
+++ b/Armament/Assets/MyScripts/PlayFab/PlayFabController.cs
@@ -55,7 +55,7 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
                     Destroy(this.gameObject);
                 }
             }
-            DontDestroyOnLoad(this.gameObject);
+           //DontDestroyOnLoad(this.gameObject);
         }
 
         public void Start()


### PR DESCRIPTION
DontDestroyOnLoad was keeping objects around that didn't need to be there. 

On the Launcher you can now hit Enter to log in, in addition to clicking the Log In button.

Eliminated the incorrect status text from joining a random room. Every time it would say "We load the Simple Room" no matter what arena it was.