### PR TITLE
Wall vote implementation

### DIFF
--- a/Armament/Assets/MyPrefabs/Resources/Original Dividing Wall.prefab
+++ b/Armament/Assets/MyPrefabs/Resources/Original Dividing Wall.prefab
@@ -12,13 +12,13 @@ GameObject:
   - component: {fileID: 2094}
   - component: {fileID: 1866}
   - component: {fileID: 2521}
-  - component: {fileID: 2737}
   - component: {fileID: 2735}
   - component: {fileID: 2739}
   - component: {fileID: 2738}
   - component: {fileID: 2740}
   - component: {fileID: 2333}
   - component: {fileID: 7353178301252863464}
+  - component: {fileID: 5380408555736249138}
   m_Layer: 0
   m_Name: Original Dividing Wall
   m_TagString: Untagged
@@ -35,8 +35,10 @@ Transform:
   m_GameObject: {fileID: 394}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.1, y: 400, z: 1100}
-  m_Children: []
+  m_LocalScale: {x: 1, y: 10, z: 20}
+  m_Children:
+  - {fileID: 4764070671421234143}
+  - {fileID: 872735522164733811}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -55,7 +57,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 394}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -98,19 +100,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &2737
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 394}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 977421e7aac7e4c4282969dc45da7c90, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  health: 500
 --- !u!114 &2735
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,3 +194,200 @@ NavMeshObstacle:
   m_CarveOnlyStationary: 0
   m_Center: {x: 0, y: 0, z: 0}
   m_TimeToStationary: 0.5
+--- !u!114 &5380408555736249138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 394}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 977421e7aac7e4c4282969dc45da7c90, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  teamA_health: 100
+  teamB_health: 100
+  wallSide: 1
+--- !u!1 &885884662160267620
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4764070671421234143}
+  - component: {fileID: 12765747227209657}
+  - component: {fileID: 1006870113082706123}
+  - component: {fileID: 7769893328943937268}
+  m_Layer: 0
+  m_Name: Side 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4764070671421234143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 885884662160267620}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.25, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1104}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &12765747227209657
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 885884662160267620}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1006870113082706123
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 885884662160267620}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 37586d7b94c1c184fad2dc72a0809884, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &7769893328943937268
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 885884662160267620}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4759988969917182721
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 872735522164733811}
+  - component: {fileID: 7512126753755214217}
+  - component: {fileID: 2386690962751751286}
+  - component: {fileID: 7216043498450303392}
+  m_Layer: 0
+  m_Name: Side 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &872735522164733811
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759988969917182721}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.25, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1104}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7512126753755214217
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759988969917182721}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2386690962751751286
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759988969917182721}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 37586d7b94c1c184fad2dc72a0809884, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &7216043498450303392
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759988969917182721}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Armament/Assets/MyScripts/Game/WallManager.cs
+++ b/Armament/Assets/MyScripts/Game/WallManager.cs
@@ -8,7 +8,6 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
 {
     public class WallManager : MonoBehaviour
     {
-
         #region MonoBehaviour CallBacks
 
         // Start is called before the first frame update

--- a/Armament/Assets/MyScripts/Game/WallTarget.cs
+++ b/Armament/Assets/MyScripts/Game/WallTarget.cs
@@ -1,4 +1,5 @@
 ﻿using Photon.Pun;
+using Photon.Realtime;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -21,15 +22,31 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         public static event WallIsDead OnWallIsDead;
 
         // Key references for the Room CustomProperties hash table (so we don't use messy string literals)
-        public const string KEY_WALL_HEALTH = "Wall Health";
+        public const string KEY_WALL_HEALTH_TEAM_A = "Wall Health for Team A";
+        public const string KEY_WALL_HEALTH_TEAM_B = "Wall Health for Team B";
 
         #endregion PublicFields
 
         #region Private Fields
 
-        [SerializeField] private float health = 100f;
-        MeshRenderer meshRenderer;
-        private float originalHealth; // keeps track of original health value
+        [SerializeField] private float teamA_health = 100f;
+        [SerializeField] private float teamB_health = 100f;
+        [Tooltip("Wall Side is either 1 or 2")]
+        [SerializeField] private int wallSide = 1; // set this manually in inspector for side 2
+
+
+        private const bool DEBUG = true; // indicates whether we are debugging this class
+        private const bool DEBUG_TakeDamage = true;
+
+        MeshRenderer teamA_meshRenderer;
+        MeshRenderer teamB_meshRenderer;
+        private float teamA_originalHealth; // keeps track of original health value
+        private float teamB_originalHealth; // keeps track of original health value
+
+        private ArrayList teamA_playersWhoHitWall;
+        private ArrayList teamB_playersWhoHitWall;
+        private int teamA_numberOfPlayersWhoCanHitWall = 0;
+        private int teamB_numberOfPlayersWhoCanHitWall = 0;
 
         #endregion Private Fields
 
@@ -37,8 +54,13 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
 
         void Awake()
         {
-            originalHealth = health;
-            meshRenderer = GetComponent<MeshRenderer>();
+            teamA_originalHealth = teamA_health;
+            teamB_originalHealth = teamB_health;
+
+            teamA_playersWhoHitWall = new ArrayList();
+            teamB_playersWhoHitWall = new ArrayList();
+            teamA_meshRenderer = transform.Find("Side 2").gameObject.GetComponent<MeshRenderer>();
+            teamB_meshRenderer = transform.Find("Side 1").gameObject.GetComponent<MeshRenderer>();
             SyncWallHealth();
         }
 
@@ -50,16 +72,19 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
         {   
             if (!PhotonNetwork.IsMasterClient)
             {
+                object value;
                 // Get the current health of the wall from Room CustomProperties
-                if (PhotonNetwork.CurrentRoom.CustomProperties.TryGetValue(KEY_WALL_HEALTH, out object value))
+                if (PhotonNetwork.CurrentRoom.CustomProperties.TryGetValue(KEY_WALL_HEALTH_TEAM_A, out value))
                 {
-                    health = (float)value;
+                    teamA_health = (float)value;
                     UpdateWallColor();
+                }
 
-                    if (health <= 0)
-                        GetComponent<BoxCollider>().enabled = false;
-                    else
-                        GetComponent<BoxCollider>().enabled = true;
+                // Get the current health of the wall from Room CustomProperties
+                if (PhotonNetwork.CurrentRoom.CustomProperties.TryGetValue(KEY_WALL_HEALTH_TEAM_B, out value))
+                {
+                    teamA_health = (float)value;
+                    UpdateWallColor();
                 }
             }
         }
@@ -68,43 +93,113 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
 
         #region Public Methods
 
-        public void TakeDamage(float amount)
-        {
-            if (PhotonNetwork.IsMasterClient)
-            {
-                health -= amount;
-                UpdateWallColor();
-
-                SyncWallHealth();
-
-                if (health <= 0)
-                {
-                    GetComponent<BoxCollider>().enabled = false;
-                    OnWallIsDead?.Invoke();
-                }
-            }
-        }
-
         /// <summary>
-        /// Wall Target doesn't care who damages it so it just calles TakeDamage(float amount)
+        /// Does nothing
         /// </summary>
         /// <param name="amount"></param>
+        public void TakeDamage(float amount){}
+
+        /// <summary>
+        /// Wall Target logs who hits it and health will represent 
+        /// </summary>
+        /// <param name="amount">Not used</param>
         /// <param name="player"></param>
         public void TakeDamage(float amount, PlayerManager player)
         {
-            TakeDamage(amount);
+            if (PhotonNetwork.IsMasterClient)
+            {
+                // Try to log player hit. 
+                // If player hits the wall for the first time...
+                if (TryLogPlayerHit(player))
+                {
+                    if (DEBUG && DEBUG_TakeDamage) Debug.LogFormat("WallTarget: TakeDamage() LOGGED PLAYER HIT player = [{0}]", player);
+
+                    if (player.GetTeam().Equals(PlayerManager.VALUE_TEAM_NAME_A))
+                    {
+                        double threshold = .5001f; // fudged the threshold number to make the math work
+                        teamA_numberOfPlayersWhoCanHitWall = CountNumberOfPlayersWhoCanHitWallSide();
+                        int numberOfPlayersWhoNeedToHitWallToKillIt = Convert.ToInt32(Math.Ceiling(teamA_numberOfPlayersWhoCanHitWall * threshold));
+
+                        int numberOfPlayersWhoHitWall = teamA_playersWhoHitWall.Count;
+
+                        teamA_health = Convert.ToInt32(100 * (numberOfPlayersWhoNeedToHitWallToKillIt - numberOfPlayersWhoHitWall) / numberOfPlayersWhoNeedToHitWallToKillIt);
+                        UpdateWallColor();
+
+                        SyncWallHealth();
+
+                        if (teamA_health <= 0)
+                            OnWallIsDead?.Invoke();
+                    }
+
+                    if (player.GetTeam().Equals(PlayerManager.VALUE_TEAM_NAME_B))
+                    {
+                        double threshold = .5001f; // fudged the threshold number to make the math work
+                        teamB_numberOfPlayersWhoCanHitWall = CountNumberOfPlayersWhoCanHitWallSide();
+                        int numberOfPlayersWhoNeedToHitWallToKillIt = Convert.ToInt32(Math.Ceiling(teamB_numberOfPlayersWhoCanHitWall * threshold));
+
+                        int numberOfPlayersWhoHitWall = teamB_playersWhoHitWall.Count;
+
+                        teamB_health = Convert.ToInt32(100 * (numberOfPlayersWhoNeedToHitWallToKillIt - numberOfPlayersWhoHitWall) / numberOfPlayersWhoNeedToHitWallToKillIt);
+                        UpdateWallColor();
+
+                        SyncWallHealth();
+
+                        if (teamB_health <= 0)
+                            OnWallIsDead?.Invoke();
+                    }
+                }
+            }
         }
         
+        /// <summary>
+        /// Logs who hit this wall target
+        /// </summary>
+        /// <param name="player">player to log</param>
+        /// <returns>true if was not already logged; false if player was already logged.</returns>
+        bool TryLogPlayerHit (PlayerManager player)
+        {
+            if (player.GetTeam().Equals(PlayerManager.VALUE_TEAM_NAME_A))
+            {
+                if (teamA_playersWhoHitWall.Contains(player))
+                    return false;
+                teamA_playersWhoHitWall.Add(player);
+                return true;
+            }
+
+            if (player.GetTeam().Equals(PlayerManager.VALUE_TEAM_NAME_B))
+            {
+                if (teamB_playersWhoHitWall.Contains(player))
+                    return false;
+                teamB_playersWhoHitWall.Add(player);
+                return true;
+            }
+
+            return false;
+        }
+
+        int CountNumberOfPlayersWhoCanHitWallSide()
+        {
+            int count = 0;
+            foreach (Player player in PhotonNetwork.PlayerList)
+            {
+                string team = ((GameObject)player.TagObject).GetComponent<PlayerManager>().GetTeam();
+                if ((wallSide == 1 && team.Equals(PlayerManager.VALUE_TEAM_NAME_A)) || 
+                    (wallSide == 2 && team.Equals(PlayerManager.VALUE_TEAM_NAME_B)))
+                    count++;
+            }
+            return count;
+        }
+
         public void ResetHealth()
         {
             // Reset wall health
-            health = originalHealth;
+            teamA_health = teamA_originalHealth;
+            teamB_health = teamB_originalHealth;
+            teamA_playersWhoHitWall = new ArrayList();
+            teamB_playersWhoHitWall = new ArrayList();
             UpdateWallColor();
 
             SyncWallHealth();
-
-            // Re-enable wall's box collider
-            GetComponent<BoxCollider>().enabled = true;
         }
 
         #endregion Public Methods
@@ -117,7 +212,9 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             if (PhotonNetwork.IsMasterClient)
             {
                 // Sync current wall health in Room CustomProperties
-                PhotonNetwork.CurrentRoom.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { {KEY_WALL_HEALTH, health }});
+                PhotonNetwork.CurrentRoom.SetCustomProperties(new ExitGames.Client.Photon.Hashtable {
+                    { KEY_WALL_HEALTH_TEAM_A, teamA_health },
+                    { KEY_WALL_HEALTH_TEAM_B, teamB_health } });
             }
         }
 
@@ -127,10 +224,15 @@ namespace Com.Kabaj.TestPhotonMultiplayerFPSGame
             //meshRenderer.material.color = Color.HSVToRGB(0, 0, Math.Max(health, 0) / originalHealth);
             
             // Trying to make wall more transparent as health decreases - not yet successful
-            float tickleMeElmoFactor = Math.Max(health, 0) / originalHealth;
+            float tickleMeElmoFactor = Math.Max(teamA_health, 0) / teamA_originalHealth;
             Color color = Color.HSVToRGB(0, 0, tickleMeElmoFactor);
             color.a = tickleMeElmoFactor;
-            meshRenderer.material.color = color;
+            teamA_meshRenderer.material.color = color;
+
+            tickleMeElmoFactor = Math.Max(teamB_health, 0) / teamB_originalHealth;
+            color = Color.HSVToRGB(0, 0, tickleMeElmoFactor);
+            color.a = tickleMeElmoFactor;
+            teamB_meshRenderer.material.color = color;
         }
 
         #endregion Private Methods


### PR DESCRIPTION
Now every player gets to vote on the wall coming down by shooting it once (and only once).

There is a threshold where >50% of the players on one team need to vote for it to come down.

The wall is visually divided into two sides (Team A side and Team B side) and the wall's health is reflected in its color. The color represents the proportion of the number of players who still need to "vote" for the wall to come down.

For example, if there are 3 players on one team, 2 of them need to "vote" for the wall to come down. If 1 player "votes" the wall's health will be at 50%.

Each team can only see the "votes" their team cast. In other words, Team A shoots the wall and Team B will see no change in the color of their side of the wall. This allows one team to surprise another team by bringing the wall down unexpectedly.